### PR TITLE
Change setBit behaviour

### DIFF
--- a/src/Data/Bits/ByteString.hs
+++ b/src/Data/Bits/ByteString.hs
@@ -128,5 +128,11 @@ instance Bits B.ByteString where
   bit i = (bit $ mod i 8) `B.cons` (B.replicate (div i 8) (255 :: Word8))
   {-# INLINE bit #-}
 
+  setBit x i
+    | B.length x >= B.length (bit i) = x .|. (paddingZeroes`B.append` bit i)
+    | otherwise = x
+    where paddingZeroes = B.replicate (B.length x - (B.length $ bit i)) (0 :: Word8)
+  {-# INLINE setBit #-}
+
   popCount x = sum $ map popCount $ B.unpack x
   {-# INLINE popCount #-}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -58,6 +58,9 @@ prop_ConstantLengthRotate x i = (B.length x) == (B.length $ rotate x i)
 prop_IdentityRotate :: B.ByteString -> Int -> Bool
 prop_IdentityRotate x i = x == rotateR (rotateL x i) i
 
+prop_ConstantLengthSetBit :: B.ByteString -> Int -> Bool
+prop_ConstantLengthSetBit x i = (B.length x) == (B.length $ setBit x i)
+
 main :: IO ()
 main = hspec $ do
   describe "AND" $ do
@@ -89,3 +92,6 @@ main = hspec $ do
       it "Length should not change on RotateR" $ property prop_ConstantLengthRotateR
       it "Length should not change on Rotate" $ property prop_ConstantLengthRotate
       it "Identity" $ property prop_IdentityRotate
+  describe "SetBit" $ do
+    context "Should have the following properties:" $ do
+      it "Length should not change on SetBit" $ property prop_ConstantLengthSetBit


### PR DESCRIPTION
Closes #2

Add padding when performing setBit to ensure that the length of the
bytestring isn't changed. The rightmost bit has index 0, consistent with the bit operation.

If the index is outside the bytestring, we return the same ByteString rather than error. This is consistent with the Word8 instance for Bits.